### PR TITLE
Version 1.0.1

### DIFF
--- a/Autodesk.Forge.Oss/Autodesk.Forge.Oss.csproj
+++ b/Autodesk.Forge.Oss/Autodesk.Forge.Oss.csproj
@@ -36,7 +36,7 @@
 
   <PropertyGroup>
     <PackageId>ricaun.Autodesk.Forge.Oss</PackageId>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <ProjectGuid>{54AC7247-0A9C-4A56-835B-D1790800647B}</ProjectGuid>
   </PropertyGroup>
 

--- a/Autodesk.Forge.Oss/Configuration.cs
+++ b/Autodesk.Forge.Oss/Configuration.cs
@@ -51,7 +51,7 @@ namespace Autodesk.Forge.Oss
         /// <returns></returns>
         private Bearer GetBearer()
         {
-            return GetBearerAsync().GetAwaiter().GetResult();
+            return Task.Run(GetBearerAsync).GetAwaiter().GetResult();
         }
 
         /// <summary>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.0.1] / 2022-12-26
 ### Fixed
-- Fix `deadlock` when convert async to sync in the `Configuration.GetBearer`.
+- Fix `deadlock` when converting async to sync in the `Configuration.GetBearer`.
 
 ## [1.0.0] / 2022-12-20
 ### General

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] / 2022-12-26
+### Fixed
+- Fix `deadlock` when convert async to sync in the `Configuration.GetBearer`.
+
 ## [1.0.0] / 2022-12-20
 ### General
 - First Release to Nuget
@@ -12,4 +16,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add `Autodesk.Forge.Oss.Tests` project
 
 [vNext]: ../../compare/1.0.0...HEAD
+[1.0.1]: ../../compare/1.0.0...1.0.1
 [1.0.0]: ../../compare/1.0.0


### PR DESCRIPTION
### Fixed
- Fix `deadlock` when converting async to sync in the `Configuration.GetBearer`.